### PR TITLE
修复TDengineCommand通过无参构造函数预先初始化IStmt异常情况

### DIFF
--- a/src/Data/Client/TDengineCommand.cs
+++ b/src/Data/Client/TDengineCommand.cs
@@ -14,6 +14,7 @@ namespace TDengine.Data.Client
 
         private TDengineConnection _connection;
         private string _commandText;
+        private bool _isPrepared;
         private IStmt _stmt;
 
         public TDengineCommand()
@@ -102,14 +103,8 @@ namespace TDengine.Data.Client
             get => _commandText;
             set
             {
-                try
-                {
-                    _stmt.Prepare(value);
-                }
-                finally
-                {
-                    _commandText = value;
-                }
+                _isPrepared = false;
+                _commandText = value;
             }
         }
 
@@ -132,7 +127,14 @@ namespace TDengine.Data.Client
         protected override DbConnection DbConnection
         {
             get => _connection;
-            set => _connection = (TDengineConnection)value;
+            set
+            {
+                _connection = (TDengineConnection)value;
+                if (_stmt == null)
+                {
+                    _stmt = _connection.client.StmtInit();
+                }
+            }
         }
 
         protected override DbParameterCollection DbParameterCollection => _parameters.Value;
@@ -156,6 +158,13 @@ namespace TDengine.Data.Client
 
         private IRows Statement()
         {
+
+            if (!_isPrepared)
+            {
+                _isPrepared = true;
+                _stmt.Prepare(_commandText);
+            }
+
             if (!_parameters.IsValueCreated || _parameters.Value.Count == 0)
             {
                 return Query();

--- a/src/Data/Client/TDengineCommand.cs
+++ b/src/Data/Client/TDengineCommand.cs
@@ -42,7 +42,7 @@ namespace TDengine.Data.Client
 
             base.Dispose(disposing);
         }
-        
+
         public override int ExecuteNonQuery()
         {
             if (_connection?.State != ConnectionState.Open)
@@ -130,7 +130,7 @@ namespace TDengine.Data.Client
             set
             {
                 _connection = (TDengineConnection)value;
-                if (_stmt == null)
+                if (_stmt == null && _connection != null)
                 {
                     _stmt = _connection.client.StmtInit();
                 }
@@ -158,7 +158,6 @@ namespace TDengine.Data.Client
 
         private IRows Statement()
         {
-
             if (!_isPrepared)
             {
                 _isPrepared = true;
@@ -169,6 +168,7 @@ namespace TDengine.Data.Client
             {
                 return Query();
             }
+
             var isInsert = _stmt.IsInsert();
 
             var pms = _parameters.Value;

--- a/test/Data.Tests/TDenginePrepareCommandTests.cs
+++ b/test/Data.Tests/TDenginePrepareCommandTests.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using Xunit;
+using TDengine.Data.Client;
+using TDengine.Driver;
+
+namespace Data.Tests
+{
+    public class TDenginePrepareCommandTests
+    {
+        [Fact]
+        public void PrepareCommandTest()
+        {
+            using var command = new TDengineCommand();
+
+            var connection =
+                new TDengineConnection(
+                    "host=localhost;port=6030;username=root;password=taosdata;protocol=Native;db=test;");
+            connection.Open();
+
+            command.CommandText = "select * from `test`.`test_table01` ";
+            command.Connection = connection;
+
+            var dbDataReader = command.ExecuteReader();
+
+            Assert.True(dbDataReader.HasRows);
+        }
+
+        
+        [Fact]
+        public void ConnectionInitCommandTest()
+        {
+            var connection =
+                new TDengineConnection(
+                    "host=localhost;port=6030;username=root;password=taosdata;protocol=Native;db=test;");
+            connection.Open();
+            using var command = new TDengineCommand(connection);
+            command.CommandText = "select * from `test`.`test_table01` ";
+            command.Connection = connection;
+
+            var dbDataReader = command.ExecuteReader();
+
+            Assert.True(dbDataReader.HasRows);
+        }
+    }
+}


### PR DESCRIPTION
在使用ado.net时，会有先初始化Command然后在Connection Open执行的情况
~~~C#
//先初始化Command
var command = new TDengineCommand();
command.CommandText = "select * from `test`.`test_table01` ";

//然后开启链接执行Command
var connection =
    new TDengineConnection(
        "host=localhost;port=6030;username=root;password=taosdata;protocol=Native;db=test;");
connection.Open();

command.Connection = connection;

var dbDataReader = command.ExecuteReader();

Assert.True(dbDataReader.HasRows);
~~~