### PR TITLE
fix: Fix null reference exception in setter that sets DbConnection property of the TDengineCommand class.

### DIFF
--- a/src/Data/Client/TDengineCommand.cs
+++ b/src/Data/Client/TDengineCommand.cs
@@ -1,8 +1,8 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Data;
 using System.Data.Common;
-using System.Threading.Tasks;
+using System.Collections.Generic;
+
 using TDengine.Driver;
 
 namespace TDengine.Data.Client
@@ -127,14 +127,7 @@ namespace TDengine.Data.Client
         protected override DbConnection DbConnection
         {
             get => _connection;
-            set
-            {
-                _connection = (TDengineConnection)value;
-                if (_stmt == null && _connection != null)
-                {
-                    _stmt = _connection.client.StmtInit();
-                }
-            }
+            set => _connection = value as TDengineConnection ?? throw new ArgumentException($"The specified connection is not of type {nameof(TDengineConnection)}.");
         }
 
         protected override DbParameterCollection DbParameterCollection => _parameters.Value;
@@ -158,7 +151,12 @@ namespace TDengine.Data.Client
 
         private IRows Statement()
         {
-            if (!_isPrepared)
+			if(_stmt == null && _connection != null)
+			{
+				_stmt = _connection.client.StmtInit();
+			}
+
+			if (!_isPrepared)
             {
                 _isPrepared = true;
                 _stmt.Prepare(_commandText);

--- a/src/Data/Client/TDengineCommand.cs
+++ b/src/Data/Client/TDengineCommand.cs
@@ -151,12 +151,12 @@ namespace TDengine.Data.Client
 
         private IRows Statement()
         {
-			if(_stmt == null && _connection != null)
-			{
-				_stmt = _connection.client.StmtInit();
-			}
+            if(_stmt == null && _connection != null)
+            {
+                _stmt = _connection.client.StmtInit();
+            }
 
-			if (!_isPrepared)
+            if (!_isPrepared)
             {
                 _isPrepared = true;
                 _stmt.Prepare(_commandText);

--- a/src/Driver/Client/Native/NativeStmt.cs
+++ b/src/Driver/Client/Native/NativeStmt.cs
@@ -80,9 +80,7 @@ namespace TDengine.Driver.Client.Native
             }
         }
 
-
-        private TAOS_MULTI_BIND[] GenerateBindList(object[] data, TaosFieldE[] fields, out IntPtr[] needFree,
-            bool isInsert)
+        private TAOS_MULTI_BIND[] GenerateBindList(object[] data, TaosFieldE[] fields, out IntPtr[] needFree, bool isInsert)
         {
             TAOS_MULTI_BIND[] binds = new TAOS_MULTI_BIND[data.Length];
             var needFreePointer = new List<IntPtr>();
@@ -92,7 +90,7 @@ namespace TDengine.Driver.Client.Native
                 {
                     num = 1
                 };
-                if (data[i] == null)
+                if (data[i] == null || Convert.IsDBNull(data[i]))
                 {
                     bind.buffer_type = (int)TDengineDataType.TSDB_DATA_TYPE_BOOL;
                     IntPtr p = Marshal.AllocHGlobal(TDengineConstant.ByteSize);
@@ -470,7 +468,6 @@ namespace TDengine.Driver.Client.Native
                         $"bind param type {array.GetType().GetElementType()} not supported");
             }
         }
-
 
         public void AddBatch()
         {

--- a/test/Data.Tests/TDengineCommandTests.cs
+++ b/test/Data.Tests/TDengineCommandTests.cs
@@ -67,41 +67,43 @@ namespace Data.Tests
         [Fact]
         public void SetConnection_DoesNotThrowException()
         {
+            //CASE 1: Set an already open connection.
             using(var command = new TDengineCommand())
             {
                 command.CommandText = "SELECT * FROM t";
                 var ex = Record.Exception(() => command.Connection = _connection);
                 Assert.Null(ex);
-			}
+            }
 
-			using(var command = new TDengineCommand())
-			{
+            //CASE 2: Set an connection that is not yet open.
+            using(var command = new TDengineCommand())
+            {
                 using(var connection = new TDengineConnection("username=root;password=taosdata"))
                 {
                     command.CommandText = "SELECT * FROM t";
                     var ex = Record.Exception(() => command.Connection = connection);
                     Assert.Null(ex);
                 }
-			}
-		}
+            }
+        }
 
         [Fact]
         public void ExecuteNonQuery_WithDBNull()
-		{
-			using(var command = new TDengineCommand(_connection))
-			{
-				command.CommandText = "create table if not exists t_dbnull (ts timestamp,v int,description nchar(100))";
-				command.ExecuteNonQuery();
-				command.CommandText = "INSERT INTO t_dbnull VALUES (?,?,?)";
-				command.Parameters.AddWithValue(DateTime.Now);
-				command.Parameters.AddWithValue(123);
+        {
+            using(var command = new TDengineCommand(_connection))
+            {
+                command.CommandText = "create table if not exists t_dbnull (ts timestamp,v int,description nchar(100))";
+                command.ExecuteNonQuery();
+                command.CommandText = "INSERT INTO t_dbnull VALUES (?,?,?)";
+                command.Parameters.AddWithValue(DateTime.Now);
+                command.Parameters.AddWithValue(123);
                 command.Parameters.AddWithValue(DBNull.Value);
 
-				int affectedRows = command.ExecuteNonQuery();
+                int affectedRows = command.ExecuteNonQuery();
 
-				Assert.Equal(1, affectedRows);
-			}
-		}
+                Assert.Equal(1, affectedRows);
+            }
+        }
 
 		[Fact]
         public void ExecuteNonQuery_WithValidCommand_ReturnsAffectedRows()

--- a/test/Data.Tests/TDengineCommandTests.cs
+++ b/test/Data.Tests/TDengineCommandTests.cs
@@ -65,6 +65,45 @@ namespace Data.Tests
         }
 
         [Fact]
+        public void SetConnection_DoesNotThrowException()
+        {
+            using(var command = new TDengineCommand())
+            {
+                command.CommandText = "SELECT * FROM t";
+                var ex = Record.Exception(() => command.Connection = _connection);
+                Assert.Null(ex);
+			}
+
+			using(var command = new TDengineCommand())
+			{
+                using(var connection = new TDengineConnection("username=root;password=taosdata"))
+                {
+                    command.CommandText = "SELECT * FROM t";
+                    var ex = Record.Exception(() => command.Connection = connection);
+                    Assert.Null(ex);
+                }
+			}
+		}
+
+        [Fact]
+        public void ExecuteNonQuery_WithDBNull()
+		{
+			using(var command = new TDengineCommand(_connection))
+			{
+				command.CommandText = "create table if not exists t_dbnull (ts timestamp,v int,description nchar(100))";
+				command.ExecuteNonQuery();
+				command.CommandText = "INSERT INTO t_dbnull VALUES (?,?,?)";
+				command.Parameters.AddWithValue(DateTime.Now);
+				command.Parameters.AddWithValue(123);
+                command.Parameters.AddWithValue(DBNull.Value);
+
+				int affectedRows = command.ExecuteNonQuery();
+
+				Assert.Equal(1, affectedRows);
+			}
+		}
+
+		[Fact]
         public void ExecuteNonQuery_WithValidCommand_ReturnsAffectedRows()
         {
             using (var command = new TDengineCommand(_connection))


### PR DESCRIPTION
var command = new TDengineCommand()
{
	CommandText = "...",
	CommandType = CommandType.Text,
};

var connection = new TDengineConnection("...");
command.DbConnection = connection;

上述代码片段中最后一行代码，因为 TDengineConnection 尚未打开，所以其内部的 client 变量为空，故而导致 TDegnineCommand.DbConnection 属性设置器中的代码引发了空引用异常。

现将 TDengineCommand 类中的 DbConnection 属性的设置器中的 _connection.client.StmtInit() 调用移动到  Statement() 方法中，将 StmtInit() 方法后置到执行方法也更为合理。